### PR TITLE
Remove onclick outside

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,13 @@ const { topBarHeight } = require('react-hamburger');
 
 Most props can either be directly passed through the `ReactHamburger` component or, where it exists, through the corresponding `theme` key.
 
-The `allowAutoClose`, `barCount`, and `TopContent` props cannot be passed through the theme object.
+The `barCount`, and `TopContent` props cannot be passed through the theme object.
 
 If you pass a prop and use the theme, the prop will take precedence.
 
 ### `children`
 
 Passing in `this.props.children` will render content in the `LinkContainer` (i.e. the slide-in-out sidebar).
-
-### General
-
-|       Name       |    Type   | Units |                                           Description                                           | Default | `theme` key |
-| :--------------: | :-------: | :---: | :---------------------------------------------------------------------------------------------: | :-----: | :---------: |
-| `allowAutoClose` | `boolean` |  N/A  | Causes the sidebar to automatically close when anywhere outside of `ReactHamburger` is clicked. |  `true` |     N/A     |
 
 ### Theme
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-hamburger",
+  "description": "A simple and fully customizable hamburger menu for React.",
   "version": "0.6.0",
   "main": "lib/index.js",
   "repository": "git@github.com:erikryanmoore/react-hamburger.git",

--- a/src/ReactHamburger.react.js
+++ b/src/ReactHamburger.react.js
@@ -21,7 +21,6 @@ import type {
 } from './types';
 
 type Props = {
-  allowAutoClose?: boolean,
   barColor: string,
   barCount?: number,
   barHeight: number,
@@ -53,7 +52,6 @@ type State = {
 
 export class ReactHamburger extends React.Component<Props, State> {
   static defaultProps = {
-    allowAutoClose: true,
     barCount: 3,
     theme: defaultTheme,
     TopContent: null,
@@ -63,43 +61,12 @@ export class ReactHamburger extends React.Component<Props, State> {
     open: false,
   }
 
-  constructor() {
-    super();
-
-    this.node = React.createRef();
-  }
-
-  componentDidMount() {
-    const { allowAutoClose } = this.props;
-    return allowAutoClose
-      ? document.addEventListener('mousedown', this.handleClick, false)
-      : null;
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClick, false);
-  }
-
   toggleLinkContainer = (value: boolean) => this.setState({ open: value });
-
-  // TODO(erikryanmoore): Need to improve the UX of this.
-  handleClickOutside = () => this.toggleLinkContainer(false);
-
-  // TODO(erikryanmoore): Add flowtype for event.
-  handleClick = (e: any) => {
-    if (this.node.current === e.target) {
-      return;
-    }
-    this.handleClickOutside();
-  }
 
   hamburgerToggle = () => {
     const { open } = this.state;
     return (open ? this.toggleLinkContainer(false) : this.toggleLinkContainer(true));
   }
-
-  // TODO(erikryanmoore): Add flowtype for node.
-  node: any
 
   hamburgerTheme: ?Theme
 
@@ -145,7 +112,6 @@ export class ReactHamburger extends React.Component<Props, State> {
       <ThemeProvider theme={hamburgerTheme}>
         <>
           <Top
-            ref={this.node}
             color={topBarColor}
             height={topBarHeight}
             gutter={topBarGutter}
@@ -179,6 +145,7 @@ export class ReactHamburger extends React.Component<Props, State> {
             color={linkContainerColor}
             hamburgerHeight={hamburgerHeight}
             maxWidth={linkContainerMaxWidth}
+            onClick={this.hamburgerToggle}
             open={open}
             padding={linkContainerPadding}
             right={right}

--- a/test/ReactHamburger.test.js
+++ b/test/ReactHamburger.test.js
@@ -40,12 +40,6 @@ describe('<ReactHamburger />', () => {
         expected: openState,
       },
       {
-        description: 'handleClickOutside should setState to closed',
-        instance: 'handleClickOutside',
-        expected: closedState,
-        state: openState,
-      },
-      {
         description: 'toggleLinkContainer should setState to open if closed',
         instance: 'toggleLinkContainer',
         instanceValues: true,


### PR DESCRIPTION
Having trouble with the feature on iOS and since mobile is usually the only time you'd want something like this, elected to take it out.